### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -10,6 +10,10 @@ on:
       - master
       - main
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   check:
     # available images: https://github.com/actions/runner-images#available-images


### PR DESCRIPTION
Potential fix for [https://github.com/Creatrix-Net/creatrix-net.github.io/security/code-scanning/22](https://github.com/Creatrix-Net/creatrix-net.github.io/security/code-scanning/22)

To fix the issue, add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the actions performed in the workflow:
- `contents: read` is sufficient for most steps, such as checking out the repository and running Prettier.
- `actions: write` may be required for the `repository-dispatch` step, which dispatches events to the repository.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `check` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
