### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lighthouse-badger.yml
+++ b/.github/workflows/lighthouse-badger.yml
@@ -7,6 +7,8 @@
 # Copyright (c) 2021 Sitdisch
 
 name: "Lighthouse Badger"
+permissions:
+  contents: read
 
 ########################################################################
 # DEFINE YOUR INPUTS AND TRIGGERS IN THE FOLLOWING


### PR DESCRIPTION
Potential fix for [https://github.com/Creatrix-Net/creatrix-net.github.io/security/code-scanning/21](https://github.com/Creatrix-Net/creatrix-net.github.io/security/code-scanning/21)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, it likely requires `contents: read` for reading repository content and possibly `contents: write` for updating files. However, we will start with `contents: read` and adjust if necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
