### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/broken-links-site.yml
+++ b/.github/workflows/broken-links-site.yml
@@ -1,5 +1,8 @@
 name: Check for broken links on site
 
+permissions:
+  contents: read
+
 on:
   workflow_run:
     workflows: [Deploy site]


### PR DESCRIPTION
Potential fix for [https://github.com/Creatrix-Net/creatrix-net.github.io/security/code-scanning/13](https://github.com/Creatrix-Net/creatrix-net.github.io/security/code-scanning/13)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Based on the workflow's tasks, it primarily needs read access to the repository contents. Write permissions are not required for this workflow, so we will set `contents: read` as the permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
