### PR TITLE
Potential fix for code scanning alert no. 12: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -4669,7 +4669,13 @@ d-references {
       const title = el.textContent;
       const link = "#" + el.getAttribute("id");
 
-      let newLine = "<li>" + '<a href="' + link + '">' + title + "</a>" + "</li>";
+      const escapeHTML = (str) => str.replace(/[&<>"']/g, (char) => {
+        const escapeMap = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
+        return escapeMap[char];
+      });
+
+      const escapedTitle = escapeHTML(title);
+      let newLine = "<li>" + '<a href="' + link + '">' + escapedTitle + "</a>" + "</li>";
       if (el.tagName == "H3") {
         newLine = "<ul>" + newLine + "</ul>";
       } else {


### PR DESCRIPTION
Potential fix for [https://github.com/Creatrix-Net/creatrix-net.github.io/security/code-scanning/12](https://github.com/Creatrix-Net/creatrix-net.github.io/security/code-scanning/12)

To fix the issue, the text extracted from `el.textContent` should be properly escaped before being inserted into the DOM as HTML. This ensures that any special characters in the text are treated as literal text rather than HTML or JavaScript. The best approach is to use a library or utility function to encode the text for safe HTML output.

**Steps to fix:**
1. Replace the direct concatenation of `title` into the `newLine` string with an escaped version of `title`.
2. Use a utility function to escape the text. For example, a simple function can replace special characters (`<`, `>`, `&`, `"`, `'`) with their corresponding HTML entities.
3. Ensure that all text content inserted into `innerHTML` is escaped.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
