### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/axe.yml
+++ b/.github/workflows/axe.yml
@@ -1,5 +1,8 @@
 name: Axe accessibility testing
 
+permissions:
+  contents: read
+
 on:
   # if you want to run this on every push uncomment the following lines
   # push:


### PR DESCRIPTION
Potential fix for [https://github.com/Creatrix-Net/creatrix-net.github.io/security/code-scanning/14](https://github.com/Creatrix-Net/creatrix-net.github.io/security/code-scanning/14)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the least privileges required for the workflow. Since the workflow does not perform any write operations, we will set `contents: read` to limit the `GITHUB_TOKEN` to read-only access. This change will apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
