### PR TITLE
Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prettier-html.yml
+++ b/.github/workflows/prettier-html.yml
@@ -3,6 +3,9 @@ name: Prettify gh-pages
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Creatrix-Net/creatrix-net.github.io/security/code-scanning/20](https://github.com/Creatrix-Net/creatrix-net.github.io/security/code-scanning/20)

To fix the issue, add a `permissions` block to the workflow. Since the workflow requires write access to the repository's contents for committing and pushing changes, the `contents: write` permission should be explicitly granted. All other permissions should be omitted or set to `none` to adhere to the principle of least privilege. The `permissions` block can be added at the root of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
