### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prettier-comment-on-pr.yml
+++ b/.github/workflows/prettier-comment-on-pr.yml
@@ -1,5 +1,9 @@
 name: Comment on pull request
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   repository_dispatch:
     types: [prettier-failed-on-pr]


### PR DESCRIPTION
Potential fix for [https://github.com/Creatrix-Net/creatrix-net.github.io/security/code-scanning/19](https://github.com/Creatrix-Net/creatrix-net.github.io/security/code-scanning/19)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow interacts with pull requests (e.g., commenting on them), it requires `pull-requests: write` permission. Additionally, it may need `contents: read` to access repository content if required.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`comment`) to limit permissions to that job only. In this case, adding it at the root level is sufficient and ensures clarity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
