### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-slim.yml
+++ b/.github/workflows/docker-slim.yml
@@ -13,10 +13,8 @@ on:
     types:
       - completed
 
-# on:
-#   push:
-#     branches:
-#       - 'master'
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/Creatrix-Net/creatrix-net.github.io/security/code-scanning/18](https://github.com/Creatrix-Net/creatrix-net.github.io/security/code-scanning/18)

To fix the issue, add a `permissions` block to the workflow. Since the workflow primarily interacts with repository contents and pushes Docker images, the permissions can be limited to `contents: read`. This ensures the workflow has only the necessary access to repository contents while preventing unintended write access.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs. Alternatively, it can be added to the specific job (`build`) if different jobs require different permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
