### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-docker-tag.yml
+++ b/.github/workflows/deploy-docker-tag.yml
@@ -1,5 +1,8 @@
 name: Docker Image CI (Upload Tag)
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/Creatrix-Net/creatrix-net.github.io/security/code-scanning/16](https://github.com/Creatrix-Net/creatrix-net.github.io/security/code-scanning/16)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's actions, it primarily interacts with Docker and does not appear to require write access to the repository contents. Therefore, the `permissions` block should be added at the root level of the workflow to apply to all jobs, with `contents: read` as the minimal permission.

**Steps to implement the fix:**
1. Add a `permissions` block at the root level of the workflow file.
2. Set `contents: read` to limit the `GITHUB_TOKEN` permissions to read-only access to repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
