### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -1,5 +1,8 @@
 name: Check for broken links
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Creatrix-Net/creatrix-net.github.io/security/code-scanning/15](https://github.com/Creatrix-Net/creatrix-net.github.io/security/code-scanning/15)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only performs read operations (checking for broken links), the `contents: read` permission is sufficient. This block should be added at the root level of the workflow to apply to all jobs, as no job-specific permissions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
