### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -1,5 +1,8 @@
 name: Docker Image CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Creatrix-Net/creatrix-net.github.io/security/code-scanning/17](https://github.com/Creatrix-Net/creatrix-net.github.io/security/code-scanning/17)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow does not modify the repository, it likely only requires `contents: read` permissions. This change should be applied at the root level of the workflow to cover all jobs unless specific jobs require additional permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
